### PR TITLE
Added a basic SSH firewall block for repeated failed logins 

### DIFF
--- a/SSH_log_checker
+++ b/SSH_log_checker
@@ -1,3 +1,15 @@
 #!/bin/bash
-logfile=$(journalctl -u ssh.service | grep "Failed Password" | awk '{print $11}' | sort | uniq -c | xargs -n 2 | awk '$1>2 { print $2}')
-echo $logfile
+
+logfile=$(journalctl -u ssh.service | grep "Failed password" | awk '{print $11}' | sort | uniq -c | xargs -n 2 | awk '$1>2 { print $2}')
+echo "The Failed Logins is/are: $logfile"
+
+read -p "Do you want to block this/these IPs (y/n)? " choice
+
+if [[ $choice == "y" ]]; then
+    for ip in $logfile; do
+        echo "Blocking $ip..."
+        sudo ufw deny from "$ip"
+    done
+else
+    echo "Skipping IP block."
+fi


### PR DESCRIPTION
This PR implements a basic firewall system that allows the user to block IP addresses after multiple failed SSH login attempts 